### PR TITLE
New API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 An [unreleased] version is not available on rubygems and is subject to changes and must not be considered final. Elements of unreleased list may be edited or removed at any time.
 
+## [unreleased]
+
+- [Added] Add Omise-Version header to request.
+- [Fixed] Fix auto expanding attribute does not play well with expand=true.
+- [Fixed] Fix bank accounts were typecasted as OmiseObject instead of being
+          typecasted as BankAccount.
+
 ## [0.1.5] 2015-07-29
 
 - [Added] Add json dependency in the gemspec.
@@ -14,10 +21,12 @@ An [unreleased] version is not available on rubygems and is subject to changes a
 ## [0.1.0] 2015-01-19
 
 - [Added] Add support for the Refund API.
-- [Added] Add a test suite that can be run locally without the need for a network connection or to set Omise keys.
+- [Added] Add a test suite that can be run locally without the need for a    
+          network connection or to set Omise keys.
 - [Added] Add a list method to retrieve a list of objects.
 - [Changed] Move typecast and load_response methods into a Util module.
-- [Removed] Remove the ability to retrieve a list by calling retrieve without arguments.
+- [Removed] Remove the ability to retrieve a list by calling retrieve without
+            arguments.
 
 ## [0.0.1] - 2014-11-18
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ create tokens. When creating a token server side you'll need card data
 transiting to and from your server and this requires that your organization be
 PCI compliant.
 
+### API version
+
+In case you want to enforce API version the application use, you can specify it
+by setting the api_version. The version specified by this settings will override
+the version setting in your account. This is useful if you have multiple
+environments with different API versions (e.g. development on the latest but
+production on the older version).
+
+```ruby
+require "omise"
+Omise.api_version = "2014-07-27"
+```
+
+It is highly recommended to set this version to the current version
+you're using.
+
 ## Quick Start
 
 After you have implemented [Omise.js](https://gitub.com/omise/omise.js) on your
@@ -56,7 +72,7 @@ charge = Omise::Charge.create({
   card: params[:omise_token]
 })
 
-if charge.captured
+if charge.paid
   # handle success
   puts "thanks"
 else

--- a/lib/omise/charge.rb
+++ b/lib/omise/charge.rb
@@ -29,35 +29,32 @@ module Omise
       assign_attributes resource(attributes).patch(attributes)
     end
 
+    def capture(options = {})
+      assign_attributes nested_resource("capture", options).post
+    end
+
     def customer(options = {})
-      if @attributes["customer"]
-        @customer ||= Customer.retrieve(@attributes["customer"], options)
-      end
+      expand_attribute Customer, "customer", options
     end
 
     def dispute(options = {})
-      if @attributes["dispute"]
-        @dispute ||= Dispute.retrieve(@attributes["dispute"], options)
-      end
+      expand_attribute Dispute, "dispute", options
     end
 
     def transaction(options = {})
-      if @attributes["transaction"]
-        @transaction ||= Transaction.retrieve(@attributes["transaction"], options)
-      end
+      expand_attribute Transaction, "transaction", options
     end
 
     def refunds
-      @refunds ||= RefundList.new(self, @attributes["refunds"])
+      list_attribute RefundList, "refunds"
     end
 
-    private
+    def captured
+      lookup_attribute_value :captured, :paid
+    end
 
-    def cleanup!
-      @customer = nil
-      @dispute = nil
-      @refunds = nil
-      @transaction = nil
+    def paid
+      lookup_attribute_value :paid, :captured
     end
   end
 end

--- a/lib/omise/config.rb
+++ b/lib/omise/config.rb
@@ -31,6 +31,5 @@ module Omise
 
   self.api_url = "https://api.omise.co"
   self.vault_url = "https://vault.omise.co"
-  self.api_version = "2014-07-27"
   self.resource = Resource
 end

--- a/lib/omise/customer.rb
+++ b/lib/omise/customer.rb
@@ -31,20 +31,11 @@ module Omise
     end
 
     def default_card(options = {})
-      if @attributes["default_card"]
-        @default_card ||= cards.retrieve(@attributes["default_card"], options)
-      end
+      expand_attribute cards, "default_card", options
     end
 
     def cards
-      @cards ||= CardList.new(self, @attributes["cards"])
-    end
-
-    private
-
-    def cleanup!
-      @default_card = nil
-      @cards = nil
+      list_attribute CardList, "cards"
     end
   end
 end

--- a/lib/omise/dispute.rb
+++ b/lib/omise/dispute.rb
@@ -24,15 +24,7 @@ module Omise
     end
 
     def charge(options = {})
-      if @attributes["charge"]
-        @charge ||= Charge.retrieve(@attributes["charge"], options)
-      end
-    end
-
-    private
-
-    def cleanup!
-      @charge = nil
+      expand_attribute Charge, "charge", options
     end
   end
 end

--- a/lib/omise/object.rb
+++ b/lib/omise/object.rb
@@ -56,5 +56,9 @@ module Omise
     def resource(*args)
       collection.resource(location, *args)
     end
+
+    def nested_resource(path, *args)
+      collection.resource([location, path].compact.join("/"), *args)
+    end
   end
 end

--- a/lib/omise/recipient.rb
+++ b/lib/omise/recipient.rb
@@ -30,15 +30,7 @@ module Omise
     end
 
     def bank_account
-      if @attributes["bank_account"]
-        @bank_account ||= BankAccount.new(@attributes["bank_account"])
-      end
-    end
-
-    private
-
-    def cleanup!
-      @bank_account = nil
+      expand_attribute BankAccount, "bank_account"
     end
   end
 end

--- a/lib/omise/refund.rb
+++ b/lib/omise/refund.rb
@@ -11,22 +11,11 @@ module Omise
     end
 
     def charge(options = {})
-      if @attributes["charge"]
-        @charge ||= Charge.retrieve(@attributes["charge"], options)
-      end
+      expand_attribute Charge, "charge", options
     end
 
     def transaction(options = {})
-      if @attributes["transaction"]
-        @transaction ||= Transaction.retrieve(@attributes["transaction"], options)
-      end
-    end
-
-    private
-
-    def cleanup!
-      @charge = nil
-      @transaction = nil
+      expand_attribute Transaction, "transaction", options
     end
   end
 end

--- a/lib/omise/resource.rb
+++ b/lib/omise/resource.rb
@@ -6,23 +6,29 @@ require "rest-client"
 require "omise/util"
 require "omise/config"
 require "omise/error"
+require "omise/version"
 
 module Omise
   class Resource
     CA_BUNDLE_PATH = File.expand_path("../../../data/ca_certificates.pem", __FILE__)
+    DEFAULT_HEADERS = {
+      user_agent: "OmiseRuby/#{Omise::VERSION} Ruby/#{RUBY_VERSION}"
+    }
 
     def initialize(url, path, key)
-      @uri = URI.parse(url)
-      @uri.path = [@uri.path, path].join
-      @resource = RestClient::Resource.new(@uri.to_s, {
+      @uri = prepare_uri(url, path)
+      @headers = prepare_headers
+      @key = key
+
+      @resource = RestClient::Resource.new(@uri, {
         user: key,
         verify_ssl: OpenSSL::SSL::VERIFY_PEER,
         ssl_ca_file: CA_BUNDLE_PATH,
-        headers: {
-          user_agent: "OmiseRuby/#{Omise::VERSION} OmiseAPI/#{Omise.api_version} Ruby/#{RUBY_VERSION}"
-        }
+        headers: @headers,
       })
     end
+
+    attr_reader :uri, :headers, :key
 
     def get(attributes = {})
       @resource.get(params: attributes) { |r| Omise::Util.load_response(r) }
@@ -38,6 +44,24 @@ module Omise
 
     def delete
       @resource.delete { |r| Omise::Util.load_response(r) }
+    end
+
+    private
+
+    def prepare_uri(url, path)
+      uri = URI.parse(url)
+      uri.path = [uri.path, path].join
+      uri.to_s
+    end
+
+    def prepare_headers
+      headers = {}.merge(DEFAULT_HEADERS)
+
+      if Omise.api_version
+        headers = headers.merge(omise_version: Omise.api_version)
+      end
+
+      headers
     end
   end
 end

--- a/lib/omise/testing/resource.rb
+++ b/lib/omise/testing/resource.rb
@@ -12,7 +12,7 @@ module Omise
       end
 
       def get(attributes = {})
-        Omise::Util.load_response(read_file("get"))
+        Omise::Util.load_response(read_file("get", attributes))
       end
 
       def patch(attributes = {})
@@ -27,10 +27,20 @@ module Omise
         Omise::Util.load_response(read_file("post"))
       end
 
-      def read_file(verb)
+      private
+
+      def generate_path(verb, attributes)
+        return verb if attributes.empty?
+        params = attributes.to_a.sort { |x,y| x.first <=> x.last }.flatten.join("-")
+        [verb, params].compact.join("-")
+      end
+
+      def read_file(verb, attributes = {})
+        path = generate_path(verb, attributes)
+
         File.read(File.expand_path(File.join(
           Omise::LIB_PATH, "..", "test", "fixtures",
-          [@uri.host, @uri.path, "-#{verb}.json"].join
+          [@uri.host, @uri.path, "-#{path}.json"].join
         )))
       end
     end

--- a/lib/omise/transfer.rb
+++ b/lib/omise/transfer.rb
@@ -31,23 +31,12 @@ module Omise
       assign_attributes resource(attributes).delete
     end
 
-    def recipient
-      if @attributes["recipient"]
-        @recipient ||= Recipient.retrieve(@attributes["recipient"])
-      end
+    def recipient(options = {})
+      expand_attribute Recipient, "recipient", options
     end
 
     def bank_account
-      if @attributes["bank_account"]
-        @bank_account ||= BankAccount.new(@attributes["bank_account"])
-      end
-    end
-
-    private
-
-    def cleanup!
-      @bank_account = nil
-      @recipient = nil
+      expand_attribute BankAccount, "bank_account"
     end
   end
 end

--- a/lib/omise/util.rb
+++ b/lib/omise/util.rb
@@ -7,7 +7,8 @@ module Omise
   module Util module_function
     def typecast(object)
       klass = begin
-        Omise.const_get(object["object"].capitalize)
+        klass_name = object["object"].split("_").map(&:capitalize).join("")
+        Omise.const_get(klass_name)
       rescue NameError
         OmiseObject
       end

--- a/lib/omise/version.rb
+++ b/lib/omise/version.rb
@@ -1,3 +1,3 @@
 module Omise
-  VERSION = "0.1.5"
+  VERSION = "0.2.0"
 end

--- a/test/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq-get-expand-true.json
+++ b/test/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq-get-expand-true.json
@@ -1,0 +1,96 @@
+{
+  "object": "charge",
+  "id": "chrg_test_4yq7duw15p9hdrjp8oq",
+  "livemode": false,
+  "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq",
+  "amount": 100000,
+  "currency": "thb",
+  "description": "Charge for order 3947",
+  "capture": true,
+  "authorized": true,
+  "captured": true,
+  "transaction": "trxn_test_4yq7duwb9jts1vxgqua",
+  "refunded": 10000,
+  "refunds": {
+    "object": "list",
+    "from": "1970-01-01T00:00:00+00:00",
+    "to": "2015-01-16T07:23:49+00:00",
+    "offset": 0,
+    "limit": 20,
+    "total": 1,
+    "data": [
+      {
+        "object": "refund",
+        "id": "rfnd_test_4yqmv79ahghsiz23y3c",
+        "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq/refunds/rfnd_test_4yqmv79ahghsiz23y3c",
+        "amount": 10000,
+        "currency": "thb",
+        "charge": "chrg_test_4yq7duw15p9hdrjp8oq",
+        "transaction": "trxn_test_4yqmv79fzpy0gmz5mmq",
+        "created": "2015-01-16T07:23:45Z"
+      }
+    ],
+    "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq/refunds"
+  },
+  "failure_code": null,
+  "failure_message": null,
+  "card": {
+    "object": "card",
+    "id": "card_test_4yq6tuucl9h4erukfl0",
+    "livemode": false,
+    "location": "/customers/cust_test_4yq6txdpfadhbaqnwp3/cards/card_test_4yq6tuucl9h4erukfl0",
+    "country": "",
+    "city": "Bangkok",
+    "postal_code": "10320",
+    "financing": "",
+    "last_digits": "4242",
+    "brand": "Visa",
+    "expiration_month": 1,
+    "expiration_year": 2017,
+    "fingerprint": "sRF/oMw2UQJJp/WbU+2/ZbVzwROjpMf1lyhOHhOqziw=",
+    "name": "JOHN DOE",
+    "security_code_check": true,
+    "created": "2015-01-15T04:03:40Z"
+  },
+  "customer": {
+    "object": "customer",
+    "id": "cust_test_4yq6txdpfadhbaqnwp3",
+    "livemode": false,
+    "location": "/customers/cust_test_4yq6txdpfadhbaqnwp3",
+    "default_card": "card_test_4yq6tuucl9h4erukfl0",
+    "email": "john.doe@example.com",
+    "description": "John Doe (id: 30)",
+    "created": "2015-01-15T04:03:52Z",
+    "cards": {
+      "object": "list",
+      "from": "1970-01-01T00:00:00+00:00",
+      "to": "2015-01-15T04:03:52+00:00",
+      "offset": 0,
+      "limit": 20,
+      "total": 1,
+      "data": [
+        {
+          "object": "card",
+          "id": "card_test_4yq6tuucl9h4erukfl0",
+          "livemode": false,
+          "location": "/customers/cust_test_4yq6txdpfadhbaqnwp3/cards/card_test_4yq6tuucl9h4erukfl0",
+          "country": "",
+          "city": "Bangkok",
+          "postal_code": "10320",
+          "financing": "",
+          "last_digits": "4242",
+          "brand": "Visa",
+          "expiration_month": 1,
+          "expiration_year": 2017,
+          "fingerprint": "sRF/oMw2UQJJp/WbU+2/ZbVzwROjpMf1lyhOHhOqziw=",
+          "name": "JOHN DOE",
+          "security_code_check": true,
+          "created": "2015-01-15T04:03:40Z"
+        }
+      ],
+      "location": "/customers/cust_test_4yq6txdpfadhbaqnwp3/cards"
+    }
+  },
+  "ip": null,
+  "created": "2015-01-15T05:00:29Z"
+}

--- a/test/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq/capture-post.json
+++ b/test/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq/capture-post.json
@@ -1,0 +1,58 @@
+{
+  "object": "charge",
+  "id": "chrg_test_4yq7duw15p9hdrjp8oq",
+  "livemode": false,
+  "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq",
+  "amount": 100000,
+  "currency": "thb",
+  "description": "Charge for order 3947",
+  "capture": true,
+  "authorized": true,
+  "captured": true,
+  "transaction": "trxn_test_4yq7duwb9jts1vxgqua",
+  "refunded": 10000,
+  "refunds": {
+    "object": "list",
+    "from": "1970-01-01T00:00:00+00:00",
+    "to": "2015-01-16T07:23:49+00:00",
+    "offset": 0,
+    "limit": 20,
+    "total": 1,
+    "data": [
+      {
+        "object": "refund",
+        "id": "rfnd_test_4yqmv79ahghsiz23y3c",
+        "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq/refunds/rfnd_test_4yqmv79ahghsiz23y3c",
+        "amount": 10000,
+        "currency": "thb",
+        "charge": "chrg_test_4yq7duw15p9hdrjp8oq",
+        "transaction": "trxn_test_4yqmv79fzpy0gmz5mmq",
+        "created": "2015-01-16T07:23:45Z"
+      }
+    ],
+    "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq/refunds"
+  },
+  "failure_code": null,
+  "failure_message": null,
+  "card": {
+    "object": "card",
+    "id": "card_test_4yq6tuucl9h4erukfl0",
+    "livemode": false,
+    "location": "/customers/cust_test_4yq6txdpfadhbaqnwp3/cards/card_test_4yq6tuucl9h4erukfl0",
+    "country": "",
+    "city": "Bangkok",
+    "postal_code": "10320",
+    "financing": "",
+    "last_digits": "4242",
+    "brand": "Visa",
+    "expiration_month": 1,
+    "expiration_year": 2017,
+    "fingerprint": "sRF/oMw2UQJJp/WbU+2/ZbVzwROjpMf1lyhOHhOqziw=",
+    "name": "JOHN DOE",
+    "security_code_check": true,
+    "created": "2015-01-15T04:03:40Z"
+  },
+  "customer": "cust_test_4yq6txdpfadhbaqnwp3",
+  "ip": null,
+  "created": "2015-01-15T05:00:29Z"
+}

--- a/test/omise/test_account.rb
+++ b/test/omise/test_account.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestAccount < Minitest::Test
-  def setup
+class TestAccount < Omise::Test
+  setup do
     @account = Omise::Account.retrieve
   end
 

--- a/test/omise/test_balance.rb
+++ b/test/omise/test_balance.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestBalance < Minitest::Test
-  def setup
+class TestBalance < Omise::Test
+  setup do
     @balance = Omise::Balance.retrieve
   end
 

--- a/test/omise/test_card.rb
+++ b/test/omise/test_card.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestCard < Minitest::Test
-  def setup
+class TestCard < Omise::Test
+  setup do
     @cards = Omise::Customer.retrieve("cust_test_4yq6txdpfadhbaqnwp3").cards
     @card = @cards.retrieve("card_test_4yq6tuucl9h4erukfl0")
   end

--- a/test/omise/test_customer.rb
+++ b/test/omise/test_customer.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestCustomer < Minitest::Test
-  def setup
+class TestCustomer < Omise::Test
+  setup do
     @customer = Omise::Customer.retrieve("cust_test_4yq6txdpfadhbaqnwp3")
   end
 

--- a/test/omise/test_dispute.rb
+++ b/test/omise/test_dispute.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestDispute < Minitest::Test
-  def setup
+class TestDispute < Omise::Test
+  setup do
     @dispute = Omise::Dispute.retrieve("dspt_test_5089off452g5m5te7xs")
   end
 

--- a/test/omise/test_recipient.rb
+++ b/test/omise/test_recipient.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestRecipient < Minitest::Test
-  def setup
+class TestRecipient < Omise::Test
+  setup do
     @recipient = Omise::Recipient.retrieve("recp_test_50894vc13y8z4v51iuc")
   end
 

--- a/test/omise/test_refund.rb
+++ b/test/omise/test_refund.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestRefund < Minitest::Test
-  def setup
+class TestRefund < Omise::Test
+  setup do
     @refunds = Omise::Charge.retrieve("chrg_test_4yq7duw15p9hdrjp8oq").refunds
     @refund = @refunds.retrieve("rfnd_test_4yqmv79ahghsiz23y3c")
   end

--- a/test/omise/test_resource.rb
+++ b/test/omise/test_resource.rb
@@ -1,0 +1,36 @@
+require "support"
+
+class TestResource < Omise::Test
+  def test_we_can_initialize_a_resource
+    resource = Omise::Resource.new(Omise.api_url, "/", "skey_xxx")
+
+    assert_instance_of Omise::Resource, resource
+  end
+
+  def test_that_the_version_header_is_not_set_if_the_version_config_is_not_set
+    resource = Omise::Resource.new(Omise.api_url, "/", "skey_xxx")
+
+    assert_instance_of Hash, resource.headers
+    assert_nil resource.headers[:omise_version]
+  end
+
+  def test_that_the_version_header_is_set_if_the_version_config_is_set
+    Omise.api_version = "2014-07-27"
+    resource = Omise::Resource.new(Omise.api_url, "/", "skey_xxx")
+
+    assert_instance_of Hash, resource.headers
+    assert_equal "2014-07-27", resource.headers[:omise_version]
+  end
+
+  def test_that_the_path_is_set
+    resource = Omise::Resource.new(Omise.api_url, "/charges", "skey_xxx")
+
+    assert_equal "https://api.omise.co/charges", resource.uri
+  end
+
+  def test_that_the_key_is_set
+    resource = Omise::Resource.new(Omise.api_url, "/charges", "skey_xxx")
+
+    assert_equal "skey_xxx", resource.key
+  end
+end

--- a/test/omise/test_token.rb
+++ b/test/omise/test_token.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestToken < Minitest::Test
-  def setup
+class TestToken < Omise::Test
+  setup do
     @token = Omise::Token.retrieve("tokn_test_4yq8lbecl0q6dsjzxr5")
   end
 

--- a/test/omise/test_transaction.rb
+++ b/test/omise/test_transaction.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestTransaction < Minitest::Test
-  def setup
+class TestTransaction < Omise::Test
+  setup do
     @transaction = Omise::Transaction.retrieve("trxn_test_4yq7duwb9jts1vxgqua")
   end
 

--- a/test/omise/test_transfer.rb
+++ b/test/omise/test_transfer.rb
@@ -1,7 +1,7 @@
 require "support"
 
-class TestTransfer < Minitest::Test
-  def setup
+class TestTransfer < Omise::Test
+  setup do
     @transfer = Omise::Transfer.retrieve("trsf_test_4yqacz8t3cbipcj766u")
   end
 

--- a/test/support.rb
+++ b/test/support.rb
@@ -3,10 +3,26 @@ require "bundler/setup"
 
 Bundler.require(:default, :test)
 
-Omise.test!
-
-# Dummy Keys
-Omise.api_key = "pkey_test_4yq6tct0llin5nyyi5l"
-Omise.vault_key = "skey_test_4yq6tct0lblmed2yp5t"
-
 require "minitest/autorun"
+
+module Omise
+  class Test < Minitest::Test
+    def before_setup
+      Omise.test!
+      Omise.api_key = "pkey_test_4yq6tct0llin5nyyi5l"
+      Omise.vault_key = "skey_test_4yq6tct0lblmed2yp5t"
+      Omise.api_version = nil
+    end
+
+    def setup
+      before_setup
+    end
+
+    def self.setup(&block)
+      define_method :setup do
+        before_setup
+        instance_exec(&block)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prepare for the new API version:
- Add Omise-Version in headers when version is set
- Fix bad typecasting for object with underscore
- Fix auto expand issues when expand=true is given
- Rename captured into paid
