### PR TITLE
Support to log HTTP requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installation
 
-Installing via rubgems:
+Installing via rubygems:
 
 ```ruby
 gem 'omise'
@@ -20,7 +20,7 @@ gem 'omise', github: 'omise/omise-ruby'
 
 ## Requirements
 
-Requires ruby 1.9.2 or above, the rest-client and json gem.
+Requires ruby 1.9.2 or above, the rest-client and json gems.
 
 ## Configuration
 
@@ -46,7 +46,7 @@ PCI compliant.
 ### API version
 
 In case you want to enforce API version the application use, you can specify it
-by setting the api_version. The version specified by this settings will override
+by setting the `api_version`. The version specified by this settings will override
 the version setting in your account. This is useful if you have multiple
 environments with different API versions (e.g. development on the latest but
 production on the older version).
@@ -58,6 +58,18 @@ Omise.api_version = "2014-07-27"
 
 It is highly recommended to set this version to the current version
 you're using.
+
+### Logging
+
+To enable log you can set `Omise.logger` with a Ruby logger. All HTTP requests and responses will be logged.
+
+To disable log, just configure `Omise.logger` to `nil`. Default is disabled.
+
+An example configuring Rails logger:
+
+```ruby
+Omise.logger = Rails.logger
+```
 
 ## Quick Start
 

--- a/lib/omise/config.rb
+++ b/lib/omise/config.rb
@@ -1,9 +1,11 @@
+require "omise/logger"
 require "omise/resource"
 
 module Omise
   class << self
     attr_writer :api_key, :vault_key
     attr_accessor :api_url, :vault_url, :api_version, :resource
+    attr_reader :logger
 
     def api_key
       get_key :api
@@ -11,6 +13,15 @@ module Omise
 
     def vault_key
       get_key :vault
+    end
+
+    def logger=(log)
+      @http_logger = Omise::Logger.new(log)
+      @logger = log
+    end
+
+    def http_logger
+      @http_logger ||= Omise::Logger.new
     end
 
     def test!

--- a/lib/omise/logger.rb
+++ b/lib/omise/logger.rb
@@ -1,0 +1,53 @@
+module Omise
+  class Logger
+    LABEL = "[Omise]".freeze
+
+    attr_reader :log
+
+    def initialize(log = nil)
+      @log = log
+    end
+
+    def log_request(request)
+      return unless log
+
+      message = StringIO.open do |s|
+        s.puts("#{LABEL} Request: #{request.method.to_s.upcase} #{request.url}")
+        append_headers(s, request.processed_headers)
+        s.puts(format_payload(request.args[:payload])) if request.args[:payload]
+        s.string
+      end
+
+      log.info(message)
+    end
+
+    def log_response(response)
+      return unless log
+
+      net_http = response.net_http_res
+
+      message = StringIO.open do |s|
+        s.puts("#{LABEL} Response: HTTP/#{net_http.http_version} #{net_http.code} #{net_http.message}")
+        append_headers(s, net_http.each_capitalized)
+        s.puts(response.body)
+        s.string
+      end
+
+      log.info(message)
+    end
+
+    private
+
+    def append_headers(message, headers)
+      headers.each do |name, value|
+        message.puts("#{name}: #{value}")
+      end
+
+      message.puts
+    end
+
+    def format_payload(payload)
+      payload.map { |key, value| "#{key}=#{value}" }.join("&")
+    end
+  end
+end

--- a/lib/omise/resource.rb
+++ b/lib/omise/resource.rb
@@ -31,22 +31,39 @@ module Omise
     attr_reader :uri, :headers, :key
 
     def get(attributes = {})
-      @resource.get(params: attributes) { |r| Omise::Util.load_response(r) }
+      @resource.get(params: attributes) do |response, request|
+        log(request, response)
+        Omise::Util.load_response(response)
+      end
     end
 
     def patch(attributes = {})
-      @resource.patch(attributes) { |r| Omise::Util.load_response(r) }
+      @resource.patch(attributes) do |response, request|
+        log(request, response)
+        Omise::Util.load_response(response)
+      end
     end
 
     def post(attributes = {})
-      @resource.post(attributes) { |r| Omise::Util.load_response(r) }
+      @resource.post(attributes) do |response, request|
+        log(request, response)
+        Omise::Util.load_response(response)
+      end
     end
 
     def delete
-      @resource.delete { |r| Omise::Util.load_response(r) }
+      @resource.delete do |response, request|
+        log(request, response)
+        Omise::Util.load_response(response)
+      end
     end
 
     private
+
+    def log(request, response)
+      Omise.http_logger.log_request(request)
+      Omise.http_logger.log_response(response)
+    end
 
     def prepare_uri(url, path)
       uri = URI.parse(url)

--- a/test/omise/test_config.rb
+++ b/test/omise/test_config.rb
@@ -1,0 +1,25 @@
+require "support"
+
+class TestConfig < Omise::Test
+  def test_that_default_values_are_set
+    assert_equal "https://api.omise.co", Omise.api_url
+    assert_equal "https://vault.omise.co", Omise.vault_url
+  end
+
+  def test_that_default_http_logger_is_set
+    assert_instance_of Omise::Logger, Omise.http_logger
+    assert_nil Omise.http_logger.log
+  end
+
+  def test_that_we_can_set_a_logger
+    logger = Logger.new(STDOUT)
+    Omise.logger = logger
+
+    assert_same logger, Omise.logger
+    assert_same logger, Omise.http_logger.log
+  end
+
+  def teardown
+    Omise.logger = nil
+  end
+end

--- a/test/omise/test_logger.rb
+++ b/test/omise/test_logger.rb
@@ -1,0 +1,69 @@
+require "support"
+
+class TestLogger < Omise::Test
+  def test_we_can_initialize_a_logger_with_default_log
+    logger = Omise::Logger.new
+
+    assert_instance_of Omise::Logger, logger
+    assert_nil logger.log
+  end
+
+  def test_we_can_initialize_a_logger_setting_a_log
+    log = Logger.new(STDOUT)
+    logger = Omise::Logger.new(log)
+
+    assert_instance_of Omise::Logger, logger
+    assert_same log, logger.log
+  end
+
+  def setup
+    @log_mock = MiniTest::Mock.new
+  end
+
+  def test_we_can_log_an_http_request
+    request = Struct.new(
+      :method,
+      :url,
+      :processed_headers,
+      :args
+    ).new(
+      :post,
+      "http://api.omise.co/path",
+      { "Header" => "value" },
+      { payload: { var1: "value1", var2: "value2" } },
+    )
+    expected_log_message = "[Omise] Request: POST http://api.omise.co/path\nHeader: value\n\nvar1=value1&var2=value2\n"
+    @log_mock.expect(:info, nil, [expected_log_message])
+
+    Omise::Logger.new(@log_mock).log_request(request)
+
+    assert @log_mock.verify
+  end
+
+  def test_we_can_log_an_http_response
+    net_http = Struct.new(
+      :http_version,
+      :code,
+      :message,
+      :each_capitalized
+    ).new(
+      "1.1",
+      200,
+      "OK",
+      [["Header", "value"]]
+    )
+    response = Struct.new(
+      :net_http_res,
+      :body
+    ).new(
+      net_http,
+      "Work my body over"
+    )
+    expected_log_message = "[Omise] Response: HTTP/1.1 200 OK\nHeader: value\n\nWork my body over\n"
+    @log_mock.expect(:info, nil, [expected_log_message])
+
+    Omise::Logger.new(@log_mock).log_response(response)
+
+    assert @log_mock.verify
+  end
+end


### PR DESCRIPTION
Delegates HTTP requests log to RestClient.

To enable log you can set `Omise.logger` with a Ruby logger. All HTTP requests will be logged.

To disable log, just configure `Omise.logger` to `nil`. Default is disabled.

An example configuring Rails logger:

``` ruby
Omise.logger = Rails.logger
```
