### PR TITLE
Fix get wrong scheduled status

### DIFF
--- a/lib/omise/schedule.rb
+++ b/lib/omise/schedule.rb
@@ -25,5 +25,9 @@ module Omise
     def destroy(attributes = {})
       assign_attributes resource(attributes).delete
     end
+
+    def destroyed?
+      self.status == "deleted" ? true : false
+    end
   end
 end

--- a/lib/omise/schedule.rb
+++ b/lib/omise/schedule.rb
@@ -27,7 +27,7 @@ module Omise
     end
 
     def destroyed?
-      self.status == "deleted" ? true : false
+      status == "deleted"
     end
   end
 end

--- a/test/fixtures/api.omise.co/schedules/schd_test_4yq7duw15p9hdrjp8oq-delete.json
+++ b/test/fixtures/api.omise.co/schedules/schd_test_4yq7duw15p9hdrjp8oq-delete.json
@@ -2,5 +2,5 @@
   "object": "schedule",
   "location": "/schedules/schd_test_4yq7duw15p9hdrjp8oq",
   "id": "schd_test_4yq7duw15p9hdrjp8oq",
-  "deleted": true
+  "status": "deleted"
 }

--- a/test/fixtures/api.omise.co/schedules/schd_test_4yq7duw15p9hdrjp8oq-get.json
+++ b/test/fixtures/api.omise.co/schedules/schd_test_4yq7duw15p9hdrjp8oq-get.json
@@ -1,6 +1,7 @@
 {
   "object": "schedule",
   "location": "/schedules/schd_test_4yq7duw15p9hdrjp8oq",
+  "status": "active",
   "id": "schd_test_4yq7duw15p9hdrjp8oq",
   "occurrences": {
     "object": "list",

--- a/test/omise/test_schedule.rb
+++ b/test/omise/test_schedule.rb
@@ -40,6 +40,14 @@ class TestSchedule < Omise::Test
     assert @schedule.destroyed?
   end
 
+  def test_that_we_can_get_correct_schedule_status_when_it_destroyed
+    refute @schedule.destroyed?
+
+    @schedule.destroy
+
+    assert @schedule.destroyed?
+  end
+
   def test_that_we_can_list_occurences
     occurrences = @schedule.occurrences
 


### PR DESCRIPTION
According to 

![image](https://user-images.githubusercontent.com/4988515/41454705-9afe54e0-70a4-11e8-9d58-c03770a46a15.png)

Schedule response is different than any APIs, it doesn't have `deleted` attribute so we have to check from `status` attribute instead.