### PR TITLE
Fix child resource does not use correct api key #30 

### DIFF
--- a/lib/omise/attributes.rb
+++ b/lib/omise/attributes.rb
@@ -4,7 +4,7 @@ module Omise
   module Attributes
     def initialize(attributes = {}, options = {})
       @attributes          = attributes
-      @options             = options
+      @options             = initialize_options(options)
       @expanded_attributes = {}
     end
 
@@ -96,10 +96,18 @@ module Omise
 
     def expand_attribute(object, key, options = {})
       if @attributes[key] && @attributes[key].is_a?(String)
-        @expanded_attributes[key] ||= object.retrieve(@attributes[key], options)
+        @expanded_attributes[key] ||= object.retrieve(@attributes[key], @options.merge(options))
       else
         self[key]
       end
+    end
+
+    # When instantiating a new instance, we'll include class's options
+    # so new object instance could use the correct api key (from parent's settings)
+    def initialize_options(options)
+      return options unless defined?(self.class.options) && !self.class.options.nil?
+
+      self.class.options.merge(options)
     end
 
     def cleanup!

--- a/lib/omise/attributes.rb
+++ b/lib/omise/attributes.rb
@@ -83,7 +83,7 @@ module Omise
     end
 
     def list_attribute(klass, key)
-      klass.new(@attributes[key], parent: self)
+      klass.new(@attributes[key], @options.merge(parent: self))
     end
 
     def list_nested_resource(klass, key, options = {})
@@ -91,7 +91,7 @@ module Omise
         return list_attribute(klass, key)
       end
 
-      klass.new(nested_resource(key, options).get, parent: self)
+      klass.new(nested_resource(key, options).get, @options.merge(parent: self))
     end
 
     def expand_attribute(object, key, options = {})

--- a/lib/omise/chain.rb
+++ b/lib/omise/chain.rb
@@ -10,7 +10,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def reload(attributes = {})

--- a/lib/omise/charge.rb
+++ b/lib/omise/charge.rb
@@ -21,7 +21,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def self.create(attributes = {})

--- a/lib/omise/customer.rb
+++ b/lib/omise/customer.rb
@@ -16,7 +16,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def self.create(attributes = {})
@@ -36,7 +36,7 @@ module Omise
     end
 
     def schedules(attributes = {})
-      List.new nested_resource("schedules", attributes).get(attributes)
+      List.new nested_resource("schedules", attributes).get(attributes), @options
     end
 
     def charge(attributes = {})

--- a/lib/omise/dispute.rb
+++ b/lib/omise/dispute.rb
@@ -13,7 +13,7 @@ module Omise
 
     def self.list(attributes = {})
       status = attributes.delete(:status)
-      List.new resource(location(status), attributes).get(attributes)
+      List.new resource(location(status), attributes).get(attributes), options
     end
 
     def self.retrieve(id = nil, attributes = {})

--- a/lib/omise/event.rb
+++ b/lib/omise/event.rb
@@ -10,7 +10,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def reload(attributes = {})

--- a/lib/omise/link.rb
+++ b/lib/omise/link.rb
@@ -16,7 +16,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def self.create(attributes = {})

--- a/lib/omise/object.rb
+++ b/lib/omise/object.rb
@@ -7,15 +7,19 @@ module Omise
 
     class << self
       attr_accessor :endpoint
+      attr_accessor :options
 
       def location(id = nil)
         [endpoint, id].compact.join("/")
       end
 
       def resource(path, attributes = {})
-        key = attributes.delete(:key) { resource_key }
+        @options = {
+          key: attributes.delete(:key) { resource_key }
+        }
+
         preprocess_attributes!(attributes)
-        Omise.resource.new(resource_url, path, key)
+        Omise.resource.new(resource_url, path, @options[:key])
       end
 
       private
@@ -53,11 +57,18 @@ module Omise
     end
 
     def resource(*args)
-      collection.resource(location, *args)
+      collection.resource(location, *prepare_args(args))
     end
 
     def nested_resource(path, *args)
-      collection.resource([location, path].compact.join("/"), *args)
+      collection.resource([location, path].compact.join("/"), *prepare_args(args))
+    end
+
+    # Update args to include current object#options
+    def prepare_args(args)
+      args[0] = @options.merge(args[0])
+
+      args
     end
   end
 end

--- a/lib/omise/recipient.rb
+++ b/lib/omise/recipient.rb
@@ -15,7 +15,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def self.create(attributes = {})

--- a/lib/omise/refund.rb
+++ b/lib/omise/refund.rb
@@ -10,7 +10,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def reload(attributes = {})

--- a/lib/omise/schedule.rb
+++ b/lib/omise/schedule.rb
@@ -7,7 +7,7 @@ module Omise
     self.endpoint = "/schedules"
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def self.retrieve(id, attributes = {})

--- a/lib/omise/transaction.rb
+++ b/lib/omise/transaction.rb
@@ -10,7 +10,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
   end
 end

--- a/lib/omise/transfer.rb
+++ b/lib/omise/transfer.rb
@@ -23,7 +23,7 @@ module Omise
     end
 
     def self.list(attributes = {})
-      List.new resource(location, attributes).get(attributes)
+      List.new resource(location, attributes).get(attributes), options
     end
 
     def reload(attributes = {})

--- a/lib/omise/version.rb
+++ b/lib/omise/version.rb
@@ -1,3 +1,3 @@
 module Omise
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end

--- a/test/omise/test_omise_object.rb
+++ b/test/omise/test_omise_object.rb
@@ -1,0 +1,78 @@
+require "support"
+
+module Omise
+  class Kettle < OmiseObject
+    def self.retrieve(id, attributes = {})
+      resource(id, attributes)
+
+      # stub data
+      new({
+        object: "kettle",
+        teapot: "teapot_1"
+      })
+    end
+
+    def collection
+      @mock ||= MiniTest::Mock.new
+    end
+
+    def update(attributes)
+      resource(attributes)
+    end
+
+    def teapot(mock)
+      expand_attribute mock, :teapot, {}
+    end
+  end
+end
+
+class TestOmiseObject < Omise::Test
+  def assert_api_key(expected_key)
+    mock = MiniTest::Mock.new
+    mock.expect(:retrieve, nil, [
+      "teapot_1",
+      expected_key
+    ])
+    yield(mock)
+
+    mock.verify
+  end
+
+  def test_that_child_object_should_use_parent_api_key_when_specified
+    test_key = "pkey_test_1"
+    kettle   = Omise::Kettle.retrieve("/test_1", key: test_key)
+
+    # child object use the same key as parent
+    assert_api_key(key: test_key) do |mock|
+      kettle.teapot(mock)
+    end
+  end
+
+  def test_that_subsequent_call_without_api_key_should_use_original_api_key
+    # change key
+    test_key = "pkey_test_1"
+    kettle   = Omise::Kettle.retrieve("/test_1", key: test_key)
+
+    assert_api_key(key: test_key) do |mock|
+      kettle.teapot(mock)
+    end
+
+    # call without key should use original key
+    kettle   = Omise::Kettle.retrieve("/test_1")
+    assert_api_key(key: Omise.secret_api_key) do |mock|
+      kettle.teapot(mock)
+    end
+  end
+
+  def test_that_instance_method_should_use_parent_api_key
+    test_key = "pkey_test_1"
+    location = "/test_1"
+    kettle   = Omise::Kettle.retrieve(location, key: test_key)
+
+    # instance method should uses the same key as parent
+    kettle.collection.expect(:resource, nil, [
+      "", { name: "Teapot", key: test_key }
+    ])
+    kettle.update(name: "Teapot")
+  end
+end


### PR DESCRIPTION
Due to the fact that `api key` is assigned to global object e.g. `Omise.secret_api_key`, this makes it difficult to maintain per instance api key and can cause some bug when switching between `api key`.

This PR fix the above issues and #30

Summary
- Fix `List` object doesn't retain api key for later calls.
- Fix child resource doesn't use api key from parent object