### PR TITLE
Add destroy method for Link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.DS_Store

--- a/lib/omise/link.rb
+++ b/lib/omise/link.rb
@@ -27,6 +27,10 @@ module Omise
       assign_attributes resource(attributes).get(attributes)
     end
 
+    def destroy(attributes = {})
+      assign_attributes resource(attributes).delete
+    end
+
     def charges(options = {})
       if options.empty?
         list_attribute ChargeList, "charges"

--- a/test/fixtures/api.omise.co/links/link_test_55pcclmznvrv9lc7r9s-delete.json
+++ b/test/fixtures/api.omise.co/links/link_test_55pcclmznvrv9lc7r9s-delete.json
@@ -1,0 +1,6 @@
+{
+  "object": "link",
+  "id": "link_test_55pcclmznvrv9lc7r9s",
+  "livemode": false,
+  "deleted": true
+}

--- a/test/omise/test_link.rb
+++ b/test/omise/test_link.rb
@@ -17,6 +17,13 @@ class TestLink < Omise::Test
     assert_equal "link_test_55pcclmznvrv9lc7r9s", @link.id
   end
 
+  def test_that_we_can_destroy_a_link
+    @link.destroy
+
+    assert @link.deleted
+    assert @link.destroyed?
+  end
+
   def test_that_we_can_list_all_links
     links = Omise::Link.list
 


### PR DESCRIPTION
### Summary
- [x] Add destroy method for Link ([Omise doc](https://www.omise.co/links-api#destroy))
- [x] Add test

### QA
You should be able to destroy a link.

1. Retrieve a link
`link = Omise::Link.retrieve("link_test_5ll4klw6mopf4nh4bi5")`

2. Destroy the link
`link.destroy`

3. Check whether the link has been destroyed
`link.destroyed?`