### PR TITLE
Add expire method for Charge

### DIFF
--- a/lib/omise/charge.rb
+++ b/lib/omise/charge.rb
@@ -44,6 +44,10 @@ module Omise
       assign_attributes nested_resource("reverse", options).post
     end
 
+    def expire(options = {})
+      assign_attributes nested_resource("expire", options).post
+    end
+
     def customer(options = {})
       if !defined?(Customer)
         require "omise/customer"

--- a/test/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq/expire-post.json
+++ b/test/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq/expire-post.json
@@ -1,0 +1,51 @@
+{
+  "object": "charge",
+  "id": "chrg_test_4yq7duw15p9hdrjp8oq",
+  "livemode": false,
+  "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq",
+  "amount": 100000,
+  "currency": "thb",
+  "description": "Charge for order 3947",
+  "capture": true,
+  "authorized": false,
+  "reversed": false,
+  "captured": false,
+  "expired": true,
+  "transaction": "trxn_test_4yq7duwb9jts1vxgqua",
+  "refunded": 0,
+  "refunds": {
+    "object": "list",
+    "from": "1970-01-01T00:00:00+00:00",
+    "to": "2015-01-16T07:23:49+00:00",
+    "offset": 0,
+    "limit": 20,
+    "total": 1,
+    "data": [
+
+    ],
+    "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq/refunds"
+  },
+  "failure_code": null,
+  "failure_message": null,
+  "card": {
+    "object": "card",
+    "id": "card_test_4yq6tuucl9h4erukfl0",
+    "livemode": false,
+    "location": "/customers/cust_test_4yq6txdpfadhbaqnwp3/cards/card_test_4yq6tuucl9h4erukfl0",
+    "country": "",
+    "city": "Bangkok",
+    "postal_code": "10320",
+    "financing": "",
+    "last_digits": "4242",
+    "brand": "Visa",
+    "expiration_month": 1,
+    "expiration_year": 2017,
+    "fingerprint": "sRF/oMw2UQJJp/WbU+2/ZbVzwROjpMf1lyhOHhOqziw=",
+    "name": "JOHN DOE",
+    "security_code_check": true,
+    "created": "2015-01-15T04:03:40Z"
+  },
+  "customer": "cust_test_4yq6txdpfadhbaqnwp3",
+  "ip": null,
+  "created": "2015-01-15T05:00:29Z"
+}

--- a/test/omise/test_charge.rb
+++ b/test/omise/test_charge.rb
@@ -111,6 +111,10 @@ class TestCharge < Omise::Test
     assert @charge.reverse
   end
 
+  def test_that_we_can_set_a_charge_to_expire
+    assert @charge.expire
+  end
+
   def test_that_search_returns_a_scoped_search
     assert_instance_of Omise::SearchScope, Omise::Charge.search
     assert_equal "charge", Omise::Charge.search.scope


### PR DESCRIPTION
### Summary
- [x] Add expire method for Charge ([Omise doc](https://www.omise.co/charges-api#expire))
- [x] Add test

### QA
You should be able to set a charge to expire.

1. Retrieve a  charge
`charge = Omise::Charge.retrieve("chrg_test_5msj6vd7vkpm1o7c8vn")`

2. Set a charge to expire
`charge.expire`

3. Check whether the charge has been set to expire
`charge.expired?`