### PR TITLE
Add accept method for Dispute

### DIFF
--- a/lib/omise/dispute.rb
+++ b/lib/omise/dispute.rb
@@ -28,6 +28,10 @@ module Omise
       assign_attributes resource(attributes).patch(attributes)
     end
 
+    def accept(attributes = {})
+      assign_attributes nested_resource("accept", attributes).patch(attributes)
+    end
+
     def charge(options = {})
       if !defined?(Charge)
         require "omise/charge"

--- a/test/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs/accept-patch.json
+++ b/test/fixtures/api.omise.co/disputes/dspt_test_5089off452g5m5te7xs/accept-patch.json
@@ -1,0 +1,12 @@
+{
+  "object": "dispute",
+  "id": "dspt_test_5089off452g5m5te7xs",
+  "livemode": false,
+  "location": "/disputes/dspt_test_5089off452g5m5te7xs",
+  "amount": 100000,
+  "currency": "thb",
+  "status": "lost",
+  "message": null,
+  "charge": "chrg_test_5089odjlzg9j7tw4i1q",
+  "created": "2015-06-02T10:22:32Z"
+}

--- a/test/omise/test_dispute.rb
+++ b/test/omise/test_dispute.rb
@@ -34,10 +34,28 @@ class TestDispute < Omise::Test
     assert_equal "dspt_test_5089off452g5m5te7xs", @dispute.id
   end
 
+  def test_that_we_can_reload_a_dispute
+    @dispute.attributes.taint
+    @dispute.reload
+
+    refute @dispute.attributes.tainted?
+  end
+
   def test_that_we_can_update_a_dispute
     @dispute.update(message: "Your dispute message")
 
     assert_equal @dispute.message, "Your dispute message"
+  end
+
+  def test_that_we_can_accept_a_dispute
+    @dispute.attributes.taint
+
+    assert_equal @dispute.status, "open"
+
+    @dispute.accept
+
+    assert_equal @dispute.status, "lost"
+    refute @dispute.attributes.tainted?
   end
 
   def test_that_we_can_retrieve_a_list_of_documents


### PR DESCRIPTION
### Summary
- [x] Add accept method for Dispute ([Omise doc](https://www.omise.co/disputes-api#accept))
- [x] Add test

### QA
You should be able to accept a dispute.

1. Retrieve a  dispute
`dispute = Omise::Dispute.retrieve("dspt_test_5msj7ya0c27fryquml7")`

2. Accept the dispute
`dispute.accept`

3. Check whether the dispute has been accepted, the status should be `lost`
`dispute.status`