### PR TITLE
Allow shortened form of ordinal numbers on Scheduler

### DIFF
--- a/lib/omise/scheduler.rb
+++ b/lib/omise/scheduler.rb
@@ -5,7 +5,7 @@ require "omise/schedule"
 module Omise
   class Scheduler
     WEEKDAYS       = Date::DAYNAMES.map(&:downcase).freeze
-    MONTH_WEEKDAYS = %w[first second third fourth last]
+    MONTH_WEEKDAYS = %w[first 1st second 2nd third 3rd fourth 4th last]
       .product(WEEKDAYS)
       .map { |d| d.join("_") }
       .freeze

--- a/test/omise/test_scheduler.rb
+++ b/test/omise/test_scheduler.rb
@@ -87,6 +87,16 @@ class TestScheduler < Omise::Test
     assert_equal "first_monday", scheduler.to_attributes[:on][:weekday_of_month]
   end
 
+  def test_we_can_set_month_with_weekday_in_other_formats
+    scheduler = @scheduler.every(1).month(on: "1st_monday")
+
+    assert_scheduler_attributes(@scheduler)
+    refute_equal scheduler.object_id, @scheduler.object_id
+    assert_equal 1, scheduler.to_attributes[:every]
+    assert_equal "month", scheduler.to_attributes[:period]
+    assert_equal "1st_monday", scheduler.to_attributes[:on][:weekday_of_month]
+  end
+
   def test_we_can_set_months_with_weekday
     scheduler = @scheduler.every(3).months(on: "last_friday")
 
@@ -154,6 +164,9 @@ class TestScheduler < Omise::Test
 
     scheduler = @scheduler.parse("every month on the third Thursday until January 1st 2020")
     assert_scheduler_attributes(scheduler, 1, "month", "2020-01-01", weekday_of_month: "third_thursday")
+
+    scheduler = @scheduler.parse("every month on the 2nd Monday until January 1st 2020")
+    assert_scheduler_attributes(scheduler, 1, "month", "2020-01-01", weekday_of_month: "2nd_monday")
 
     scheduler = @scheduler.parse("every 3 months on 1, 2 and 3 until January 1st 2020")
     assert_scheduler_attributes(scheduler, 3, "month", "2020-01-01", days_of_month: [1, 2, 3])


### PR DESCRIPTION
### Summary
- [x] Fixes #27 
- [x] Add tests

### QA
You should be able to use a shortened form of ordinal numbers when creating a schedule.

```
scheduler = Omise::Charge.schedule({
  customer:    "cust_test_5msjaq18bqd958d10ew",
  card:        "card_test_5msjanzl07ys23rctug",
  amount:      100000,
  description: "Membership fee"
})

schedule = scheduler.every(1).month(on: "2nd_monday")
  .start_date("2022-11-01")
  .end_date("2022-12-31")
  .start
```