### PR TITLE
Add a new method to fetch all events belonging to a charge

### DIFF
--- a/lib/omise/charge.rb
+++ b/lib/omise/charge.rb
@@ -68,6 +68,10 @@ module Omise
       expand_attribute Transaction, "transaction", options
     end
 
+    def events(attributes = {})
+      List.new nested_resource("events", attributes).get(attributes)
+    end
+
     def refunds
       list_attribute RefundList, "refunds"
     end

--- a/test/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq/events-get.json
+++ b/test/fixtures/api.omise.co/charges/chrg_test_4yq7duw15p9hdrjp8oq/events-get.json
@@ -1,0 +1,28 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "event",
+      "id": "evnt_test_5moztki4ickw5gxwsrh",
+      "livemode": false,
+      "location": "/events/evnt_test_5moztki4ickw5gxwsrh",
+      "key": "charge.update",
+      "created_at": "2021-01-29T02:05:20Z"
+    },
+    {
+      "object": "event",
+      "id": "evnt_test_5mozta5zc6wdx4genou",
+      "livemode": false,
+      "location": "/events/evnt_test_5mozta5zc6wdx4genou",
+      "key": "charge.create",
+      "created_at": "2021-01-29T02:04:31Z"
+    }
+  ],
+  "limit": 20,
+  "offset": 0,
+  "total": 2,
+  "location": "/charges/chrg_test_4yq7duw15p9hdrjp8oq/events",
+  "order": "chronological",
+  "from": "1970-01-01T00:00:00Z",
+  "to": "2021-02-07T10:04:29Z"
+}

--- a/test/omise/test_charge.rb
+++ b/test/omise/test_charge.rb
@@ -120,4 +120,11 @@ class TestCharge < Omise::Test
     assert_instance_of Omise::Scheduler, Omise::Charge.schedule
     assert_equal "charge", Omise::Charge.schedule.type
   end
+
+  def test_that_we_can_fetch_an_event_list_for_a_given_charge
+    events = @charge.events
+
+    assert events
+    assert_instance_of Omise::List, events
+  end
 end


### PR DESCRIPTION
### Summary
- [x] Add a new method to fetch all events belonging to a charge ([Omise doc](https://www.omise.co/charges-api#list_events))
- [x] Add test

### QA
You should be able to fetch a list of events belonging to a given charge.

1. Retrieve a charge
`charge = Omise::Charge.retrieve("chrg_test_5mozta4qq7c8rt2doub")`

2. List all events of the charge
`charge.events`