### PR TITLE
parse JSON instead of load JSON

### DIFF
--- a/lib/omise/util.rb
+++ b/lib/omise/util.rb
@@ -17,7 +17,7 @@ module Omise
     end
 
     def load_response(response)
-      object = JSON.load(response)
+      object = JSON.parse(response)
 
       if object["object"] == "error"
         raise Omise::Error, object


### PR DESCRIPTION
## Description

- Issue ID: https://github.com/omise/omise-ruby/issues/60

## Decision(s)

`JSON.load` does not raise rescue-friendly errors. (See https://github.com/omise/omise-ruby/issues/60.)  
Use `JSON.parse` like everyone else.
 
## Business impact (if any)

When the exception is rescued properly, the business interruption is prevented.